### PR TITLE
Fixed Command Injection

### DIFF
--- a/index.js
+++ b/index.js
@@ -491,8 +491,8 @@ class NodeClam {
 
         try {
             await fs_access(path, fs.constants.R_OK);
-
-            const {stdout} = await cp_exec(version_cmds[scanner]);
+            version_cmds_exec = version_cmds[scanner].split(' ');
+            const {stdout} = await cp_execfile(version_cmds_exec[0], version_cmds_exec[2]);
             if (stdout.toString().match(/ClamAV/) === null) {
                 if (this.settings.debug_mode) console.log(`${this.debug_label}: Could not verify the ${scanner} binary.`);
                 return false;

--- a/index.js
+++ b/index.js
@@ -492,7 +492,7 @@ class NodeClam {
         try {
             await fs_access(path, fs.constants.R_OK);
             version_cmds_exec = version_cmds[scanner].split(' ');
-            const {stdout} = await cp_execfile(version_cmds_exec[0], version_cmds_exec[2]);
+            const {stdout} = await cp_execfile(version_cmds_exec[0], [version_cmds_exec[2]]);
             if (stdout.toString().match(/ClamAV/) === null) {
                 if (this.settings.debug_mode) console.log(`${this.debug_label}: Could not verify the ${scanner} binary.`);
                 return false;


### PR DESCRIPTION
:gear: **Fix:**

I had real fun fixing this one! The code was really clean and tracing what variables were passing through what functions were awesome! :smile: 

The fix is implemented by using `cp_execfile()` (`execFile`) instead of `cp_exec()` (`exec`).

:question: **How:**

The `_is_clamav_binary()` function was vulnerable to Command Injection, it accepted a variable `scanner` to determine what utility to choose, ie: `clamdscan` and `clamscan`.

The `execFile()` executes a system command from a binary path, ie: `/bin/ls` for the `ls` command. And as the `scanner` variable is passed to `version_cmds{}` to concatenate with argument `--version`, it was easy to implement the fix. The `path` was set as `/usr/bin/clamdscan` in the [constructor function](https://github.com/418sec/clamscan/blob/1a989169127d1b0f575d1f2a41df8b030cb2bbf8/index.js#L84) so just splitting the command and passing it to `execFile()` can fix the issue.

:spiral_notepad: **Proof of Concept:**

_**place it in the root folder of the project as `poc.js`**_

```javascript
var Root = require("./index.js"); 
var fs = require("fs"); 
var attack_code = "echo vulnerable > create.txt"; 
var root = new Root(); 
fs.mkdir(attack_code + "&", function(){}); 
root.init({"clamscan": {'path': attack_code + "&"}});
```

:fire: **Fix On Action:**

:apple: _**Mac:**_

    $ brew install clamav
    $ node poc.js

:penguin: _**Linux:**_

    $ sudo apt-get install clamav
    $ node poc.js

:heart: **After Fix:**

![clamscan-command-injection-fix](https://user-images.githubusercontent.com/26198477/79016051-a9f07480-7b8b-11ea-8e10-519aa4976588.png)

_**As you can see in the above screenshot, no file named `create.txt` was created!**_ :heavy_check_mark: 

<hr>

### :v: Fixed

<hr>